### PR TITLE
API 설계 3 : LiDAR 데이터 리스트 조회

### DIFF
--- a/src/main/java/project/graduation/controller/CollectController.java
+++ b/src/main/java/project/graduation/controller/CollectController.java
@@ -3,6 +3,7 @@ package project.graduation.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,10 +11,14 @@ import project.graduation.config.resultform.ResultException;
 import project.graduation.config.resultform.ResultResponse;
 import project.graduation.dto.AddressDto;
 import project.graduation.dto.CollectDto;
+import project.graduation.dto.CollectResponseDto;
 import project.graduation.dto.GPSDto;
 import project.graduation.entity.GeneralFile;
 import project.graduation.service.CollectService;
 import project.graduation.service.GeneralFileService;
+
+import java.util.List;
+import java.util.Map;
 
 import static project.graduation.config.resultform.ResultResponseStatus.REQUEST_ERROR;
 
@@ -34,5 +39,16 @@ public class CollectController {
         }
 
         return new ResultResponse<>(collectService.uploadLidarFile(address, location, file), null);
+    }
+
+    @GetMapping("/{addressId}")
+    public ResultResponse<List<CollectResponseDto>> getLidarFiles(@PathVariable String addressId,
+                                                                  @RequestParam(defaultValue = "1") Integer page,
+                                                                  @RequestParam(defaultValue = "10") Integer size) {
+        Page<CollectResponseDto> collectList = collectService.getLidarFiles(addressId, page, size);
+        return new ResultResponse<>(null, collectList.getContent(),
+                Map.of("totalCount", collectList.getTotalElements(),
+                        "totalPage", collectList.getTotalPages()
+                ));
     }
 }

--- a/src/main/java/project/graduation/dto/AddressDto.java
+++ b/src/main/java/project/graduation/dto/AddressDto.java
@@ -3,13 +3,11 @@ package project.graduation.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import project.graduation.entity.Address;
-import project.graduation.entity.Floor;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Data
+@NoArgsConstructor
 public class AddressDto {
     private String id; //apiId;
     @NotNull @NotBlank

--- a/src/main/java/project/graduation/dto/CollectResponseDto.java
+++ b/src/main/java/project/graduation/dto/CollectResponseDto.java
@@ -1,0 +1,54 @@
+package project.graduation.dto;
+
+import lombok.Data;
+import project.graduation.entity.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Data
+public class CollectResponseDto {
+
+    private String collectId;
+    private String generalFileId;
+    private Long fileSize;
+    private String programId;
+    private String gpsId;
+    private String addressId;
+    private String addressName;
+    private String roadAddressName;
+    private String placeName;
+
+    private String floorId;
+    private Integer floor;
+
+    private String createdDate;
+    private String lastModifiedDate;
+
+    public CollectResponseDto(Collect collect) {
+        this.collectId = String.valueOf(collect.getCollectId());
+
+        this.generalFileId = String.valueOf(collect.getGeneralFile().getFileId());
+        this.fileSize = collect.getGeneralFile().getSize();
+
+        if(collect.getProgram() != null)
+            this.programId = String.valueOf(collect.getProgram().getProgramId());
+
+        this.gpsId = String.valueOf(collect.getGps().getGpsId());
+
+        this.addressId = collect.getFloor().getAddress().getAddressId();
+        this.addressName = collect.getFloor().getAddress().getAddressName();
+        this.roadAddressName = collect.getFloor().getAddress().getRoadAddressName();
+        this.placeName = collect.getFloor().getAddress().getPlaceName();
+
+        this.floorId = String.valueOf(collect.getFloor().getFloorId());
+        this.floor = collect.getFloor().getFloor();
+
+        this.createdDate = convertToString(collect.getCreatedDate());
+        this.lastModifiedDate = convertToString(collect.getLastModifiedDate());
+    }
+
+    public static String convertToString(LocalDateTime time) {
+        return time.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
+}

--- a/src/main/java/project/graduation/repository/CollectRepository.java
+++ b/src/main/java/project/graduation/repository/CollectRepository.java
@@ -1,9 +1,14 @@
 package project.graduation.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import project.graduation.entity.Collect;
 
+import java.util.List;
 import java.util.UUID;
 
-public interface CollectRepository extends JpaRepository<Collect, UUID> {
+public interface CollectRepository extends JpaRepository<Collect, UUID>, CollectRepositoryCustom {
+
 }

--- a/src/main/java/project/graduation/repository/CollectRepositoryCustom.java
+++ b/src/main/java/project/graduation/repository/CollectRepositoryCustom.java
@@ -1,0 +1,9 @@
+package project.graduation.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import project.graduation.dto.CollectResponseDto;
+
+public interface CollectRepositoryCustom {
+    Page<CollectResponseDto> findAllByAddressId(String addressId, Pageable pageable);
+}

--- a/src/main/java/project/graduation/repository/CollectRepositoryCustomImpl.java
+++ b/src/main/java/project/graduation/repository/CollectRepositoryCustomImpl.java
@@ -1,0 +1,55 @@
+package project.graduation.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import project.graduation.dto.CollectResponseDto;
+import project.graduation.entity.Collect;
+import project.graduation.entity.QGPS;
+import project.graduation.entity.QGeneralFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static project.graduation.entity.QAddress.address;
+import static project.graduation.entity.QCollect.collect;
+import static project.graduation.entity.QGeneralFile.generalFile;
+import static project.graduation.entity.QGPS.gPS;
+import static project.graduation.entity.QProgram.program;
+import static project.graduation.entity.QFloor.floor1;
+
+public class CollectRepositoryCustomImpl implements CollectRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public CollectRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+    @Override
+    public Page<CollectResponseDto> findAllByAddressId(String addressId, Pageable pageable){
+        List<Collect> content = queryFactory
+                .select(collect)
+                .from(collect)
+                .join(collect.generalFile, generalFile)
+                .join(collect.gps, gPS)
+                .leftJoin(collect.program, program)
+                .join(collect.floor, floor1)
+                .fetchJoin()
+                .where(floor1.address.addressId.eq(addressId))
+                .orderBy(collect.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(collect)
+                .from(collect)
+                .join(collect.floor, floor1)
+                .fetchJoin()
+                .where(floor1.address.addressId.eq(addressId))
+                .fetch().size();
+
+        return new PageImpl<>(content.stream().map(CollectResponseDto::new).collect(Collectors.toList()), pageable, total);
+    }
+}

--- a/src/main/java/project/graduation/service/CollectService.java
+++ b/src/main/java/project/graduation/service/CollectService.java
@@ -3,14 +3,20 @@ package project.graduation.service;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import project.graduation.dto.AddressDto;
 import project.graduation.dto.CollectDto;
+import project.graduation.dto.CollectResponseDto;
 import project.graduation.dto.GPSDto;
 import project.graduation.entity.*;
 import project.graduation.repository.CollectRepository;
+
+import java.util.List;
 
 @Transactional(readOnly = true)
 @Slf4j
@@ -40,5 +46,10 @@ public class CollectService {
         collect = collectRepository.save(collect);
 
         return new CollectDto(collect);
+    }
+
+    public Page<CollectResponseDto> getLidarFiles(String addressId, Integer page, Integer size){
+        PageRequest pageable = PageRequest.of(page-1, size, Sort.by(Sort.Direction.DESC, "createdDate"));
+        return collectRepository.findAllByAddressId(addressId, pageable);
     }
 }


### PR DESCRIPTION
# 개요
- Issue: #5 
- UFR-APP (사용자 앱 기능 요구사항)
  - [UFR-APP-006](https://github.com/yumble/GraduationProject/wiki#ufr-app-006)
- UFR-WEB (사용자 웹 기능 요구사항)
  - [UFR-WEB-004](https://github.com/yumble/GraduationProject/wiki#ufr-web-004)

# 추가 혹은 변경된 클래스
- [x] CollectController : getLidarFiles Function
- [x] CollectService : getLidarFiles Function
- [x] CollectRepository : QueryDSL 쿼리 연결을 위해 `implements CollectRepositoryCustom` 추가
- [x] CollectRepositoryCustom : findAllByAddressId 함수 선언
- [x] CollectRepositoryCustomImpl findAllByAddressId 정의-> QueryDSL로 쿼리 작성
- [x] CollectListDto : LiDAR파일 리스트 조회 API 리턴 객체
- [x] AddressDto -> @NoArgsConstructor 추가

# API 개발 로직 설명

1. CollectController : `getLidarFiles()` function 에서 측정된 라이더 파일 리스트를 반환하고, 총 건물 개수, 총 페이지 수를 같이 리턴하는 함수. addressId 를 받으면 해당 건물에 대한 측정 파일리스트 반환.
```java
    @GetMapping({"","/{addressId}"})
    public ResultResponse<List<CollectListDto>> getLidarFiles(@PathVariable(required = false) String addressId,
                                                              @RequestParam(required = false, defaultValue = "1") Integer page,
                                                              @RequestParam(required = false, defaultValue = "10") Integer size) {
        Page<CollectListDto> collectList = collectService.getLidarFiles(addressId, page, size);
        return new ResultResponse<>(null, collectList.getContent(),
                Map.of("totalCount", collectList.getTotalElements(),
                        "totalPage", collectList.getTotalPages()
                ));
    }
```

2. CollectService : `getLidarFiles()` function 에서 PageRequest 객체를 생성하고 `collectRepository.findAllByaddressId(addressId, pageable)` 호출하고 결과 값을 반환
```java
    public Page<CollectListDto> getLidarFiles(String addressId, Integer page, Integer size){
        PageRequest pageable = PageRequest.of(page-1, size, Sort.by(Sort.Direction.DESC, "createdDate"));
        return collectRepository.findAllByAddressId(addressId, pageable);
    }
```

3. CollectRepositoryCustomImpl : `findAllByAddressId()` Function -> QueryDSL을 사용하여 쿼리생성
- CollectRepository : `extends CollectRepositoryCustom` 추가
- CollectRepositoryCustom : `Page<CollectListDto> findAllByAddressId(String addressId, Pageable pageable);` 선언 -> Implementation은 CollectRepositoryCustomImpl 클래스에서.
```java
    @Override
    public Page<CollectListDto> findAllByAddressId(String addressId, Pageable pageable){
        List<Collect> content = queryFactory
                .select(collect)
                .from(collect)
                .join(collect.generalFile, generalFile).fetchJoin()
                .join(collect.gps, gPS).fetchJoin()
                .leftJoin(collect.program, program).fetchJoin()
                .join(collect.floor, floor1).fetchJoin()
                .join(collect.floor.address, address).fetchJoin()
                .where(addressIdEq(addressId))
                .orderBy(collect.createdDate.desc())
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();

        long total = queryFactory
                .select(collect)
                .from(collect)
                .join(collect.floor, floor1).fetchJoin()
                .join(collect.floor.address, address).fetchJoin()
                .where(addressIdEq(addressId))
                .fetch().size();

        return new PageImpl<>(content.stream().map(CollectListDto::new).collect(Collectors.toList()), pageable, total);
    }
```
- 쿼리설명 
  - 조회 쿼리랑, count 쿼리랑 구별
  - 쿼리는 fetchJoin으로 쿼리 즉시로딩 -> N+1 문제 해결
  - 정렬은 최근 날짜 우선으로 정렬
  - 페이징은 pageable 객체를 이용해서 적용
  - count 쿼리는 필요없는 join 테이블을 덜어내고 간단하게 쿼리를 작성해 조회

4. CollectListDto : API 결과를 리턴할 객체
- 특징
  - DB에서 가져오는 것들 중 UUID 타입은 String으로 변환
  - 날짜들은 convertToString 함수를 통해 "yyyy-MM-dd HH:mm" 형식으로 리턴